### PR TITLE
feat: Add button to UI which can call the Thread Export. #2

### DIFF
--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React, { useCallback, useEffect } from "react";
 import { type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { LinkIcon, OverflowHorizontalIcon, VisibilityOnIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import ExportArchiveIcon from "@vector-im/compound-design-tokens/assets/web/icons/export-archive";
 
 import { type ButtonEvent } from "../elements/AccessibleButton";
 import dis from "../../../dispatcher/dispatcher";
@@ -21,6 +22,8 @@ import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOpti
 import { WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import { type ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
+import Modal from "../../../Modal";
+import ExportDialog from "../../views/dialogs/ExportDialog";
 
 export interface ThreadListContextMenuProps {
     mxEvent: MatrixEvent;
@@ -73,6 +76,19 @@ const ThreadListContextMenu: React.FC<ThreadListContextMenuProps> = ({
         [mxEvent, closeThreadOptions, permalinkCreator],
     );
 
+    const exportThread = useCallback(
+        async (evt: ButtonEvent | undefined): Promise<void> => {
+            evt?.preventDefault();
+            evt?.stopPropagation();
+            // TODO: Remove console logging
+            console.log(`[called from 'Thread overview' sidebar] ThreadListContextMenu::exportThread(), eventId=${mxEvent.getId()}, roomId=${mxEvent.getRoomId()}`);
+            // TODO: Replace with creation of arbitrary `ExportDialog`, but adapted to the current Thread
+            Modal.createDialog(ExportDialog);
+            closeThreadOptions();
+        },
+        [mxEvent, closeThreadOptions],
+    );
+
     useEffect(() => {
         onMenuToggle?.(menuDisplayed);
     }, [menuDisplayed, onMenuToggle]);
@@ -116,6 +132,11 @@ const ThreadListContextMenu: React.FC<ThreadListContextMenuProps> = ({
                                 icon={<LinkIcon />}
                             />
                         )}
+                        <IconizedContextMenuOption
+                            onClick={(e) => exportThread(e)}
+                            label={_t("timeline|mab|export_thread")}
+                            icon={<ExportArchiveIcon />}
+                        />
                     </IconizedContextMenuOptionList>
                 </IconizedContextMenu>
             )}

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -96,6 +96,8 @@ import {
     MessageTimestampViewModel,
     type MessageTimestampViewModelProps,
 } from "../../../viewmodels/message-body/MessageTimestampViewModel.ts";
+import Modal from "../../../Modal";
+import ExportDialog from "../../views/dialogs/ExportDialog";
 
 export type GetRelationsForEvent = (
     eventId: string,
@@ -560,6 +562,16 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         if (!permalinkCreator) return;
         const matrixToUrl = permalinkCreator.forEvent(mxEvent.getId()!);
         await copyPlaintext(matrixToUrl);
+    };
+
+    private exportThread = async (evt: ButtonEvent): Promise<void> => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        const { mxEvent } = this.props;
+        console.log(`[called from 'All threads' sidebar] EventTile::exportThread(), eventId=${mxEvent.getId()}, roomId=${mxEvent.getRoomId()}`);
+
+        // TODO: Replace with creation of arbitrary `ExportDialog`, but adapted to the current Thread
+        Modal.createDialog(ExportDialog);
     };
 
     private onRoomReceipt = (ev: MatrixEvent, room: Room): void => {
@@ -1394,6 +1406,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             <EventTileThreadToolbar
                                 viewInRoom={this.viewInRoom}
                                 copyLinkToThread={this.copyLinkToThread}
+                                exportThread={this.exportThread}
                             />
                         )}
 

--- a/src/components/views/rooms/EventTile/EventTileThreadToolbar.tsx
+++ b/src/components/views/rooms/EventTile/EventTileThreadToolbar.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX } from "react";
 import { LinkIcon, VisibilityOnIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import ExportArchiveIcon from "@vector-im/compound-design-tokens/assets/web/icons/export-archive";
 
 import { RovingAccessibleButton } from "../../../../accessibility/RovingTabIndex";
 import Toolbar from "../../../../accessibility/Toolbar";
@@ -17,9 +18,11 @@ import { type ButtonEvent } from "../../elements/AccessibleButton";
 export function EventTileThreadToolbar({
     viewInRoom,
     copyLinkToThread,
+    exportThread,
 }: {
     viewInRoom: (evt: ButtonEvent) => void;
     copyLinkToThread: (evt: ButtonEvent) => void;
+    exportThread: (evt: ButtonEvent) => void;
 }): JSX.Element {
     return (
         <Toolbar className="mx_MessageActionBar" aria-label={_t("timeline|mab|label")} aria-live="off">
@@ -38,6 +41,14 @@ export function EventTileThreadToolbar({
                 key="copy_link_to_thread"
             >
                 <LinkIcon />
+            </RovingAccessibleButton>
+            <RovingAccessibleButton
+                className="mx_MessageActionBar_iconButton"
+                onClick={exportThread}
+                title={_t("timeline|mab|export_thread")}
+                key="export_thread"
+            >
+                <ExportArchiveIcon />
             </RovingAccessibleButton>
         </Toolbar>
     );

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3551,6 +3551,7 @@
         "mab": {
             "collapse_reply_chain": "Collapse quotes",
             "copy_link_thread": "Copy link to thread",
+            "export_thread": "Export thread",
             "expand_reply_chain": "Expand quotes",
             "label": "Message Actions",
             "view_in_room": "View in room"


### PR DESCRIPTION
UI has been updated on two places (see screenshots below):
1. `ThreadListContextMenu`: Rendered in UI as “Thread overview” which has a Toolbar at the top
2. `EventTileThreadToolbar`: Rendered in UI as “All threads” > Toolbar

<br>

**Current functionality:**
- Upon clicking on any of these two buttons, a default ExportDialog is rendered.
- In these functions, called `exportThread` in both instances, the code for calling the export will be placed.
- Currently, a placeholder action is triggered (writing info about the action to the console).

---

### Screenshots of UI

_UI: “Thread overview”_
<img width="500" alt="From  Thread Overview" src="https://github.com/user-attachments/assets/bf1a2621-6e3d-4c1b-99b2-bc407e64f149" />


_UI: “All threads”_
<img width="500" alt="From  All threads" src="https://github.com/user-attachments/assets/cf7cf96c-a6a9-4a0e-a267-1352bb1c4ad3" />